### PR TITLE
Correctly create time coordinates

### DIFF
--- a/cmlreaders/test/test_timeseries.py
+++ b/cmlreaders/test/test_timeseries.py
@@ -9,20 +9,20 @@ from cmlreaders.timeseries import TimeSeries
 
 class TestTimeSeries:
 
-    @pytest.mark.parametrize("tstart",[0,1])
-    def test_make_time_array_tstart(self,tstart):
+    @pytest.mark.parametrize("tstart", [0, 1])
+    def test_make_time_array_tstart(self, tstart):
         data = np.random.random((1, 32, 2))
         rate = 1000
 
-        ts = TimeSeries(data, rate,tstart=tstart)
-        assert_equal([tstart, tstart+1], ts.time)
+        ts = TimeSeries(data, rate, tstart=tstart)
+        assert_equal([tstart, tstart + 1], ts.time)
 
-    @pytest.mark.parametrize("samplerate",[50,1000,5000])
-    def test_make_time_array_samplerate(self,samplerate):
-        data=np.random.random((1,1,100))
-        ts = TimeSeries(data,samplerate=samplerate)
+    @pytest.mark.parametrize("samplerate", [50, 1000, 5000])
+    def test_make_time_array_samplerate(self, samplerate):
+        data = np.random.random((1, 1, 100))
+        ts = TimeSeries(data, samplerate=samplerate)
         assert len(ts.time) == ts.data.shape[-1]
-        assert_equal(ts.time[1]-ts.time[0], 1000./samplerate)
+        assert_equal(ts.time[1] - ts.time[0], 1000. / samplerate)
 
     @pytest.mark.parametrize("data", [
         np.random.random((1, 32, 100)),

--- a/cmlreaders/test/test_timeseries.py
+++ b/cmlreaders/test/test_timeseries.py
@@ -8,15 +8,21 @@ from cmlreaders.timeseries import TimeSeries
 
 
 class TestTimeSeries:
-    def test_make_time_array(self):
+
+    @pytest.mark.parametrize("tstart",[0,1])
+    def test_make_time_array_tstart(self,tstart):
         data = np.random.random((1, 32, 2))
         rate = 1000
 
-        ts = TimeSeries(data, rate)
-        assert_equal([0, 1], ts.time)
+        ts = TimeSeries(data, rate,tstart=tstart)
+        assert_equal([tstart, tstart+1], ts.time)
 
-        ts = TimeSeries(data, rate, tstart=1)
-        assert_equal([1, 2], ts.time)
+    @pytest.mark.parametrize("samplerate",[50,1000,5000])
+    def test_make_time_array_samplerate(self,samplerate):
+        data=np.random.random((1,1,100))
+        ts = TimeSeries(data,samplerate=samplerate)
+        assert len(ts.time) == ts.data.shape[-1]
+        assert_equal(ts.time[1]-ts.time[0], 1000./samplerate)
 
     @pytest.mark.parametrize("data", [
         np.random.random((1, 32, 100)),

--- a/cmlreaders/timeseries.py
+++ b/cmlreaders/timeseries.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.signal
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 
@@ -39,7 +40,7 @@ class TimeSeries(object):
 
         self.data = data
         self.samplerate = samplerate
-        self.time = self._make_time_array(tstart)
+        self.time = self._make_time_array(tstart)  #: time in milliseconds
 
         if epochs is not None:
             if len(epochs) != self.data.shape[0]:
@@ -58,9 +59,9 @@ class TimeSeries(object):
         self.attrs = attrs if attrs is not None else {}
 
     def _make_time_array(self, tstart):
-        rate = self.samplerate / 1000.
+        rate = 1000. / self.samplerate
         n_samples = self.data.shape[-1]
-        return np.arange(tstart, n_samples * 1 / rate + tstart, rate)
+        return np.arange(tstart, n_samples * rate + tstart, rate)
 
     @classmethod
     def concatenate(cls, series: List["TimeSeries"], dim="events") -> "TimeSeries":

--- a/cmlreaders/timeseries.py
+++ b/cmlreaders/timeseries.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy.signal
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 


### PR DESCRIPTION
Previously:

``` python
>>> ts = TimeSeries(np.empty((1,1,100),sample_rate=50)
>>> len(ts.time)
800
```
Now:
``` python
>>> ts = TimeSeries(np.empty((1,1,100),sample_rate=50)
>>> len(ts.time)
100
```
