### PR TITLE
Don't use generic CSV reader for electrode_categories

### DIFF
--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -46,8 +46,11 @@ class TextReader(BaseCMLReader):
 
 class CSVReader(BaseCMLReader):
     """ Generic reader class for loading csv files with headers """
-    data_types = ['prior_stim_results', 'electrode_coordinates',
-                  'electrode_categories', 'target_selection_table']
+    data_types = [
+        "electrode_coordinates",
+        "prior_stim_results",
+        "target_selection_table",
+    ]
 
     def __init__(self, data_type, subject, localization, experiment=None,
                  file_path=None, rootdir="/", **kwargs):


### PR DESCRIPTION
`electrode_categories` was listed twice. We should also update the metaclass to not allow this to avoid potential bugs. I think this managed to still use the right reader likely because the correct reader was defined later.