### PR TITLE
Update requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas
   - source activate test-environment
   - pip install -r requirements.txt
-  - conda install -y -c pennmem -c conda-forge classiflib ptsa=1
+  - conda install -y -c pennmem -c conda-forge classiflib ptsa=1 ramutils
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas=0.22
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas
   - source activate test-environment
   - pip install -r requirements.txt
   - conda install -y -c pennmem -c conda-forge ramutils ptsa=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas
   - source activate test-environment
   - pip install -r requirements.txt
-  - conda install -y -c pennmem -c conda-forge ramutils ptsa=1
+  - conda install -y -c pennmem -c conda-forge ptsa=1
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pandas
   - source activate test-environment
   - pip install -r requirements.txt
-  - conda install -y -c pennmem -c conda-forge ptsa=1
+  - conda install -y -c pennmem -c conda-forge classiflib ptsa=1
   - python setup.py install
 
 script:

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -385,7 +385,7 @@ class BaseReportDataReader(BaseCMLReader):
     -----
     By default, a python class is returned. For report data read with this class
     a python object is the only supported return type. The returned class will
-    be `ramutils.reports.summary.Classifiersummary`
+    be `ramutils.reports.summary.ClassifierSummary`
 
     """
     data_types = ["classifier_summary"]

--- a/cmlreaders/test/test_readers.py
+++ b/cmlreaders/test/test_readers.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 
-from classiflib.container import ClassifierContainer
-
 from cmlreaders.readers import (
     BasicJSONReader, TextReader, CSVReader, EEGMetaReader,
     ElectrodeCategoriesReader, EventReader, LocalizationReader, MontageReader,
@@ -350,25 +348,20 @@ class TestReportSummaryReader:
 
 
 class TestClassifierContainerReader:
+    @patch("classiflib.container.ClassifierContainer")
     @pytest.mark.parametrize("method", ['pyobject'])
     @pytest.mark.parametrize("data_type", [
         'baseline_classifier', 'used_classifier'])
-    def test_as_methods(self, method, data_type):
+    def test_as_methods(self, ClassifierContainer, method, data_type):
         file_path = datafile(data_type + ".zip")
         reader = ClassifierContainerReader(data_type, subject='R1389J',
                                            experiment='catFR5', session=1,
                                            localization=0, file_path=file_path)
 
-        pyobj_expected_types = {
-            'baseline_classifier': ClassifierContainer,
-            'used_classifier': ClassifierContainer,
-        }
-
         method_name = "as_{}".format(method)
         callable_method = getattr(reader, method_name)
-        data = callable_method()
-        assert data is not None
-        assert type(data) == pyobj_expected_types[data_type]
+        callable_method()
+        ClassifierContainer.load.assert_called()
 
     @pytest.mark.parametrize("method", ['binary'])
     @pytest.mark.parametrize("data_type", [

--- a/cmlreaders/test/test_readers.py
+++ b/cmlreaders/test/test_readers.py
@@ -262,8 +262,8 @@ class TestBaseReportDataReader:
     @pytest.mark.parametrize("subject,experiment,session", [
         ('R1409D', 'catFR1', '1'),
     ])
-    def test_as_methods(self, ClassifierSummary, method, data_type, subject, experiment, session,
-                        ):
+    def test_as_methods(self, ClassifierSummary, method, data_type, subject,
+                        experiment, session):
         file_path = datafile(data_type + ".h5")
 
         reader = BaseReportDataReader(data_type, subject=subject,
@@ -280,7 +280,7 @@ class TestBaseReportDataReader:
 
         data = callable_method()
         assert data is not None
-        ClassifierSummary.from_hdf.assert_called()
+        assert ClassifierSummary.from_hdf.call_count == 1
 
     @pytest.mark.parametrize("method", ['hdf'])
     @pytest.mark.parametrize("data_type", ["classifier_summary"])
@@ -313,7 +313,7 @@ class TestReportSummaryReader:
             method_name = "as_{}".format(method)
             func = getattr(reader, method_name)
             func()
-            cls.from_hdf.assert_called()
+            assert cls.from_hdf.call_count == 1
 
     def test_load_nonstim_session(self):
         file_path = datafile('session_summary' + ".h5")
@@ -361,7 +361,7 @@ class TestClassifierContainerReader:
         method_name = "as_{}".format(method)
         callable_method = getattr(reader, method_name)
         callable_method()
-        ClassifierContainer.load.assert_called()
+        assert ClassifierContainer.load.call_count == 1
 
     @pytest.mark.parametrize("method", ['binary'])
     @pytest.mark.parametrize("data_type", [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
-pandas==0.22
+pandas>=0.22,!=0.23.0
 numpy
 scipy
 codecov


### PR DESCRIPTION
- Removes dependency on `ramutils` for testing (mostly addresses #73) by using `unittest.mock.patch` in tests
- Updates `pandas` dependency to allow for version 0.23.1 which fixed the JSON normalization bug