### PR TITLE
Load task_events by default for PS4

### DIFF
--- a/cmlreaders/cmlreader.py
+++ b/cmlreaders/cmlreader.py
@@ -178,7 +178,7 @@ class CMLReader(object):
             if self.experiment.startswith("PS2"):
                 data_type = "task_events"
             elif self.experiment.startswith("PS4"):
-                data_type = "ps4_events"
+                data_type = "task_events"
             else:
                 data_type = "all_events"
 

--- a/cmlreaders/test/test_cmlreader.py
+++ b/cmlreaders/test/test_cmlreader.py
@@ -120,8 +120,8 @@ class TestCMLReader:
     def test_ps4_events(self, subject, experiment, session, rhino_root):
         reader = CMLReader(subject, experiment, session, rootdir=rhino_root)
         events = reader.load("events")
-        ps4_events = reader.load("ps4_events")
-        assert all(events == ps4_events)
+        task_events = reader.load("task_events")
+        assert all(events == task_events)
 
     @pytest.mark.rhino
     def test_ps2_events(self, rhino_root):


### PR DESCRIPTION
The ps4_events are just debug output from Ramulator.