### PR TITLE
Fixes for loading pyFR data

### DIFF
--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -100,7 +100,8 @@ rhino_paths = {
         'protocols/{protocol}/subjects/{subject}/experiments/{experiment}/sessions/{session}/behavioral/current_processed/ps4_events.json'
     ],
     'sources': [
-        'protocols/{protocol}/subjects/{subject}/experiments/{experiment}/sessions/{session}/ephys/current_processed/sources.json'
+        "protocols/{protocol}/subjects/{subject}/experiments/{experiment}/sessions/{session}/ephys/current_processed/sources.json",
+        "data/eeg/{subject}/eeg.noreref/params.txt",
     ],
 
     # Processed EEG data basename

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -131,6 +131,10 @@ class EventReader(BaseCMLReader):
         if self.session is not None:
             df = df[df["session"] == self.session]
 
+        # ensure we have an experiment column
+        if "experiment" not in df:
+            df.loc[:, "experiment"] = self.experiment
+
         return df
 
     def as_dataframe(self):

--- a/cmlreaders/test/test_eeg.py
+++ b/cmlreaders/test/test_eeg.py
@@ -225,13 +225,13 @@ class TestFileReaders:
 
 @pytest.mark.rhino
 class TestEEGReader:
-    # FIXME: add LTP, pyFR cases
-    @pytest.mark.parametrize("subject,index,channel", [
-        ("R1298E", 87, "CH88"),  # Split EEG
-        ("R1387E", 13, "CH14"),  # Ramulator HDF5
+    @pytest.mark.parametrize("subject,experiment,index,channel", [
+        ("R1298E", "FR1", 87, "CH88"),  # Split EEG
+        ("R1387E", "FR1", 13, "CH14"),  # Ramulator HDF5
+        ("TJ039", "pyFR", 14, "CH15"),  # pyFR
     ])
-    def test_eeg_reader(self, subject, index, channel, rhino_root):
-        reader = CMLReader(subject=subject, experiment='FR1', session=0,
+    def test_eeg_reader(self, subject, experiment, index, channel, rhino_root):
+        reader = CMLReader(subject=subject, experiment=experiment, session=0,
                            rootdir=rhino_root)
         events = reader.load("events")
         events = events[events["type"] == "WORD"].iloc[:2]

--- a/cmlreaders/test/test_readers.py
+++ b/cmlreaders/test/test_readers.py
@@ -221,6 +221,7 @@ class TestEventReader:
         path = datafile(filename)
         df = EventReader.fromfile(path)
         assert df.columns[0] == "eegoffset"
+        assert "experiment" in df.columns
         assert len(df)
 
 


### PR DESCRIPTION
- Adds search path for `params.txt` (old-style `sources.json`)
- Ensures there is an `experiment` column when loading Matlab events

Closes #179.