### PR TITLE
Load pyFR params.txt by session

### DIFF
--- a/cmlreaders/base_reader.py
+++ b/cmlreaders/base_reader.py
@@ -79,6 +79,7 @@ class BaseCMLReader(object, metaclass=_MetaReader):
                  localization: Optional[int] = 0,
                  montage: Optional[int] = 0,
                  file_path: Optional[str] = None,
+                 eeg_basename: Optional[str] = None,
                  rootdir: Optional[str] = None):
 
         # This is for mocking in tests, do not remove!
@@ -91,6 +92,7 @@ class BaseCMLReader(object, metaclass=_MetaReader):
         self.localization = localization
         self.montage = montage
         self.data_type = data_type
+        self.eeg_basename = eeg_basename
         self.rootdir = get_root_dir(rootdir)
 
         # in-memory cached result (if enabled)
@@ -125,7 +127,8 @@ class BaseCMLReader(object, metaclass=_MetaReader):
         if self._file_path is None and self.data_type != 'eeg':
             finder = PathFinder(subject=self.subject, experiment=self.experiment,
                                 session=self.session, localization=self.localization,
-                                montage=self.montage, rootdir=self.rootdir)
+                                montage=self.montage, eeg_basename=self.eeg_basename,
+                                rootdir=self.rootdir)
             self._file_path = finder.find(self.data_type)
         return self._file_path
 

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -101,7 +101,9 @@ rhino_paths = {
     ],
     'sources': [
         "protocols/{protocol}/subjects/{subject}/experiments/{experiment}/sessions/{session}/ephys/current_processed/sources.json",
+        "data/eeg/{subject}/eeg.noreref/{eeg_basename}.params.txt",
         "data/eeg/{subject}/eeg.noreref/params.txt",
+
     ],
 
     # Processed EEG data basename

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -74,7 +74,7 @@ class PathFinder(object):
 
         self.localization = str(localization)
         self.montage = str(montage)
-        self.eeg_basename=eeg_basename
+        self.eeg_basename = eeg_basename
 
         self._paths = rhino_paths
 

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -30,6 +30,7 @@ class PathFinder(object):
                  session: Optional[int] = None,
                  localization: Optional[int] = 0,
                  montage: Optional[int] = 0,
+                 eeg_basename: Optional[str] = None,
                  rootdir: Optional[str] = None):
         """Instantiates a PathFinder object using the known information
 
@@ -73,6 +74,7 @@ class PathFinder(object):
 
         self.localization = str(localization)
         self.montage = str(montage)
+        self.eeg_basename=eeg_basename
 
         self._paths = rhino_paths
 
@@ -165,7 +167,8 @@ class PathFinder(object):
                                                experiment=self.experiment,
                                                session=self.session,
                                                localization=self.localization,
-                                               montage=self.montage)
+                                               montage=self.montage,
+                                               eeg_basename=self.eeg_basename)
         return expected_path
 
     def _get_most_recent_ramulator_folder(self, base_folder_path):

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -534,9 +534,11 @@ class EEGReader(BaseCMLReader):
             # determine experiment, session, dtype, and sample rate
             experiment = ev["experiment"].unique()[0]
             session = ev["session"].unique()[0]
+            basename = os.path.basename(filename)
             finder = PathFinder(subject=self.subject,
                                 experiment=experiment,
                                 session=session,
+                                eeg_basename=basename,
                                 rootdir=self.rootdir)
             sources = EEGMetaReader.fromfile(finder.find("sources"),
                                              subject=self.subject)

--- a/cmlreaders/test/test_eeg.py
+++ b/cmlreaders/test/test_eeg.py
@@ -522,6 +522,7 @@ class TestLoadEEG:
         (["R1111M"], ["FR1"]),
         (["R1111M"], ["FR1", "catFR1"]),
         (["R1111M", "R1286J"], ["FR1"]),
+        (["TJ015"], ["pyFR"]),
     ])
     def test_load_multisession(self, subjects, experiments, rhino_root):
         events = CMLReader.load_events(subjects, experiments, rootdir=rhino_root)

--- a/cmlreaders/test/test_path_finder.py
+++ b/cmlreaders/test/test_path_finder.py
@@ -83,9 +83,9 @@ def test_session_params(rhino_root, use_basename):
     subject = 'TJ012'
     eeg_basename = 'TJ012_20Apr10_1329'
     if use_basename:
-        finder = PathFinder(subject=subject,eeg_basename=eeg_basename,
+        finder = PathFinder(subject=subject, eeg_basename=eeg_basename,
                             rootdir=rhino_root)
     else:
-        finder = PathFinder(subject=subject,rootdir=rhino_root)
+        finder = PathFinder(subject=subject, rootdir=rhino_root)
     path = finder.find('sources')
     assert (eeg_basename in path) == use_basename

--- a/cmlreaders/test/test_path_finder.py
+++ b/cmlreaders/test/test_path_finder.py
@@ -75,3 +75,17 @@ def test_get_ramulator_files(ramulator_files_finder):
 
     folder_path = ramulator_files_finder.find("ramulator_session_folder")
     assert folder_path.endswith('20171027_164013')
+
+
+@pytest.mark.rhino
+@pytest.mark.parametrize('use_basename', [True, False])
+def test_session_params(rhino_root, use_basename):
+    subject = 'TJ012'
+    eeg_basename = 'TJ012_20Apr10_1329'
+    if use_basename:
+        finder = PathFinder(subject=subject,eeg_basename=eeg_basename,
+                            rootdir=rhino_root)
+    else:
+        finder = PathFinder(subject=subject,rootdir=rhino_root)
+    path = finder.find('sources')
+    assert (eeg_basename in path) == use_basename


### PR DESCRIPTION
PathFinder will now load params.txt files by subject + basename (e.g. "TJ001_01Jan93_0816")
as well as by subject alone. 

Closes #181 