### PR TITLE
Text reader

### DIFF
--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -10,7 +10,6 @@ from cmlreaders.base_reader import BaseCMLReader
 from cmlreaders.exc import (
     MissingParameter, UnmetOptionalDependencyError, UnsupportedRepresentation,
 )
-import pandas.errors as pd_errors
 
 
 class TextReader(BaseCMLReader):

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -10,6 +10,7 @@ from cmlreaders.base_reader import BaseCMLReader
 from cmlreaders.exc import (
     MissingParameter, UnmetOptionalDependencyError, UnsupportedRepresentation,
 )
+import pandas.errors as pd_errors
 
 
 class TextReader(BaseCMLReader):
@@ -36,7 +37,7 @@ class TextReader(BaseCMLReader):
 
     def as_dataframe(self):
         if self.data_type == "jacksheet":
-            sep = None  # autodetect if separated by space or tab
+            sep = '\s+'  # Split on any whitespace
         else:
             sep = ","  # read_csv's default value
 


### PR DESCRIPTION
Now uses '\s+' as separator  for jacksheets, rather than autodetection