### PR TITLE
fix in RamulatorHDF5Reader for subjects with elec1-elec2 and elec2-el…

### DIFF
--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -20,7 +20,7 @@ from cmlreaders.path_finder import PathFinder
 from cmlreaders.readers.readers import EventReader
 from cmlreaders.util import get_protocol, get_root_dir
 from cmlreaders.warnings import MissingChannelsWarning
-
+from itertools import compress
 
 class EEGMetaReader(BaseCMLReader):
     """Reads the ``sources.json`` or ``params.txt`` files which describes

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -343,6 +343,13 @@ class RamulatorHDF5Reader(BaseEEGReader):
                     bpinfo['ch0_label'][:], bpinfo['ch1_label'][:]
                 )
             ]
+            # added this to filter the montage, removing dupes in the same way as above in the read() function
+            idxs = np.empty(len(all_nums), dtype=bool)
+            idxs.fill(True)
+            for i, pair in enumerate(all_nums):
+                if pair in all_nums[:i] or pair[::-1] in all_nums[:i]:
+                    idxs[i] = False
+            all_nums=list(compress(all_nums,idxs))
 
         # Create a mask of channels that appear in both the passed scheme and
         # the recorded data.


### PR DESCRIPTION
…ec1 in h5 montage

  File "/anaconda2/envs/analpy/lib/python3.7/site-packages/cmlreaders/readers/eeg.py", line 378, in rereference
    return data[:, channel_inds, :], labels
This fix should address the 

IndexError: boolean index did not match indexed array along dimension 1; dimension is 124 but corresponding boolean dimension is 125

that had been occurring in the rereference method for certain System 3 subjects from before the Dec-2017 bptools update that eliminated any (including flipped) duplicates in the montage.