### PR TITLE
fix wrong session error message

### DIFF
--- a/cmlreaders/cmlreader.py
+++ b/cmlreaders/cmlreader.py
@@ -300,8 +300,8 @@ class CMLReader(object):
                     raise ValueError(
                         'Events must correspond to the session with which ' +
                         'the reader was initialized: ' +
-                        self.session + ' (events correspond to ' +
-                        events['session'].iloc[0] + ')')
+                        str(self.session) + ' (events correspond to ' +
+                        str(events['session'].iloc[0]) + ')')
             if "rel_start" not in kwargs or "rel_stop" not in kwargs:
                 raise IncompatibleParametersError(
                     "rel_start and rel_stop are required keyword arguments"


### PR DESCRIPTION
seems to expect a string but sessions are often provided as integers