### PR TITLE
cmlreaders version 0.10.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,13 @@
 Changes
 =======
+Version 0.10.5
+-------------
+**2024-1-24**
+
+* Added system 4 files to PathFinder, including `archived_eeg` which points to replaced elemem eeg
+* Loading events and EGG will automatically modify ``session`` field to match 'session' in data index,
+  fixing issues where events dataframe contains 'original session' value
+  
 Version 0.10.4
 -------------
 **2023-8-1**

--- a/cmlreaders/__init__.py
+++ b/cmlreaders/__init__.py
@@ -8,6 +8,6 @@ from .path_finder import PathFinder  # noqa
 from .readers import *  # noqa
 from .cmlreader import CMLReader  # noqa
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 version_info = namedtuple("VersionInfo", "major,minor,patch")(
     *__version__.split('.'))

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -153,7 +153,7 @@ rhino_paths = {
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/eeg_data.edf",
     ],
     "archived_eeg": [
-        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem{timestamped_dir}/eeg_archive/eeg_data.edf",
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/eeg_archive/eeg_data.edf",
     ],
     "odin_config": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/config_files/{subject}_*.csv",

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -152,6 +152,9 @@ rhino_paths = {
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/eeg_timeseries.h5",
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/eeg_data.edf",
     ],
+    "archived_eeg": [
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem{timestamped_dir}/eeg_archive/eeg_data.edf"
+    ],
     "odin_config": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/config_files/{subject}_*.csv",
     ],
@@ -244,4 +247,5 @@ elemem_files = (
     "experiment_config",
     "raw_eeg",
     "elemem_session_folder",
+    "archived_eeg"
 )

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -153,7 +153,7 @@ rhino_paths = {
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/eeg_data.edf",
     ],
     "archived_eeg": [
-        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem{timestamped_dir}/eeg_archive/eeg_data.edf"
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem{timestamped_dir}/eeg_archive/eeg_data.edf",
     ],
     "odin_config": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/config_files/{subject}_*.csv",

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -128,6 +128,7 @@ rhino_paths = {
     ],
     "session_json": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/session.json",
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/session.jsonl",
     ],
     "ramulator_session_folder": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/*",

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -133,16 +133,24 @@ rhino_paths = {
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/*",
         "protocols/r1/subjects/{subject}/experiments/{experiment}/sessions/{session}/ephys/current_source/host_pc/*",
     ],
+    # Elemem-related information
+    "elemem_session_folder": [
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/*",
+        "protocols/r1/subjects/{subject}/experiments/{experiment}/sessions/{session}/ephys/current_source/elemem/*",
+    ],
     # There can be multiple timestamped folders for the host pc files for when
     # a session is restarted
     "event_log": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/event_log.json",
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/event.log",
     ],
     "experiment_config": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/experiment_config.json",
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/experiment_config.json",
     ],
     "raw_eeg": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/eeg_timeseries.h5",
+        "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/elemem/{timestamped_dir}/eeg_data.edf",
     ],
     "odin_config": [
         "data10/RAM/subjects/{subject}/behavioral/{experiment}/session_{session}/host_pc/{timestamped_dir}/config_files/{subject}_*.csv",
@@ -229,3 +237,11 @@ used_classifier_files = ("used_classifier", "excluded_pairs", "all_pairs")
 
 # All Ramulator files/directories
 ramulator_files = host_pc_files + used_classifier_files + ("ramulator_session_folder",)
+
+# All Elemem files/directories
+elemem_files = (
+    "event_log",
+    "experiment_config",
+    "raw_eeg",
+    "elemem_session_folder",
+)

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -121,7 +121,7 @@ class PathFinder(object):
         elemem_path = elemem_wildcard.format(subject=subject_montage,
                                              experiment=self.experiment,
                                              session=self.session)
-        if os.path.exists(elemem_path):
+        if os.path.exists(os.path.join(self.rootdir, elemem_path)):
             return 4.0
         else:
             return 3.0  # only 4.0 is matched on, but may want to fully implement

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -125,7 +125,6 @@ class PathFinder(object):
             return 4.0
         else:
             return 3.0  # only 4.0 is matched on, but may want to fully implement
-        
 
     def find(self, data_type):
         """
@@ -170,11 +169,11 @@ class PathFinder(object):
             if self.system_version == 4.0:       # system 4
                 folder_wildcard = self._paths['elemem_session_folder'][0]
                 elemem_session_folder = folder_wildcard.format(
-                    subject=subject_montage, experiment=self.experiment, 
+                    subject=subject_montage, experiment=self.experiment,
                     session=self.session)
-                
+
                 timestamped_dir = self._get_most_recent_elemem_folder(elemem_session_folder)
-                
+
                 if data_type == 'elemem_session_folder':
                     return timestamped_dir
             else:                     # system 3 (don't think will work for systems 1 and 2)
@@ -231,14 +230,14 @@ class PathFinder(object):
         latest_directory = latest[latest.rfind("/") + 1:]
 
         return latest_directory
-    
+
     def _get_most_recent_elemem_folder(self, base_folder_path):
         timestamped_directories = glob.glob(os.path.join(self.rootdir, base_folder_path))
 
         # start of directory should be subject code
         timestamped_directories = [
             d for d in timestamped_directories
-            if os.path.isdir(d) and d[:len(self.subject)]==self.subject
+            if os.path.isdir(d) and d[:len(self.subject)] == self.subject
         ]
 
         # sort such that most recent appears first
@@ -246,11 +245,11 @@ class PathFinder(object):
 
         if len(timestamped_directories) == 0:
             raise RuntimeError("No timestamped folder found in elemem folder.")
-        
+
         # only return the values from the final "/" to the end
         latest = timestamped_directories[0]
         latest_directory = latest[latest.rfind("/") + 1:]
-        
+
         return latest_directory
 
     def _find_single_path(self, paths, **kwargs):

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -237,7 +237,7 @@ class PathFinder(object):
         # start of directory should be subject code
         timestamped_directories = [
             d for d in timestamped_directories
-            if os.path.isdir(d) and d[:len(self.subject)] == self.subject
+            if os.path.isdir(d) and os.path.basename(d)[:len(self.subject)] == self.subject
         ]
 
         # sort such that most recent appears first

--- a/cmlreaders/path_finder.py
+++ b/cmlreaders/path_finder.py
@@ -10,7 +10,6 @@ from .constants import rhino_paths, localization_files, montage_files, \
     subject_files, session_files, ramulator_files, elemem_files, \
     PYFR_SUBJECT_CODE_PREFIXES
 from .util import get_root_dir
-#from .data_index import get_data_index --> causes circular import, have to infer system version
 # from .warnings import MultiplePathsFoundWarning
 
 __all__ = ['PathFinder']
@@ -113,18 +112,21 @@ class PathFinder(object):
         return subject_files
 
     def _determine_system_version(self):
-        elemem_wildcard = self._paths["elemem_session_folder"][0]
+        elemem_wildcard = self._paths["elemem_session_folder"][0].rstrip('*')
+
+        subject_montage = self.subject
         if self.montage != '0':
             subject_montage = "_".join([self.subject, self.montage])
-        elemem_path = elemem_wildcard.format(subject=subject_montage, 
-                                             experiment=self.experiment, 
+
+        elemem_path = elemem_wildcard.format(subject=subject_montage,
+                                             experiment=self.experiment,
                                              session=self.session)
         if os.path.exists(elemem_path):
             return 4.0
         else:
             return 3.0  # only 4.0 is matched on, but may want to fully implement
+        
 
-    
     def find(self, data_type):
         """
 
@@ -171,12 +173,11 @@ class PathFinder(object):
                     subject=subject_montage, experiment=self.experiment, 
                     session=self.session)
                 
-                timestamped_dir = self._get_most_recent_elemem_folder(
-                    elemem_session_folder)
+                timestamped_dir = self._get_most_recent_elemem_folder(elemem_session_folder)
                 
                 if data_type == 'elemem_session_folder':
                     return timestamped_dir
-            else:                                # system 3 (don't think will work for systems 1 and 2)
+            else:                     # system 3 (don't think will work for systems 1 and 2)
                 folder_wildcard = self._paths['ramulator_session_folder'][0]
                 ramulator_session_folder = folder_wildcard.format(
                     subject=subject_montage, experiment=self.experiment,
@@ -232,12 +233,11 @@ class PathFinder(object):
         return latest_directory
     
     def _get_most_recent_elemem_folder(self, base_folder_path):
-        timestamped_directories = glob.glob(os.path.join(self.rootdir, 
-                                                         base_folder_path))
-        
+        timestamped_directories = glob.glob(os.path.join(self.rootdir, base_folder_path))
+
         # start of directory should be subject code
         timestamped_directories = [
-            d for d in timestamped_directories 
+            d for d in timestamped_directories
             if os.path.isdir(d) and d[:len(self.subject)]==self.subject
         ]
 
@@ -250,7 +250,7 @@ class PathFinder(object):
         # only return the values from the final "/" to the end
         latest = timestamped_directories[0]
         latest_directory = latest[latest.rfind("/") + 1:]
-
+        
         return latest_directory
 
     def _find_single_path(self, paths, **kwargs):

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -243,10 +243,14 @@ class EventReader(BaseCMLReader):
 
         first = ["eegoffset"]
         df = df[first + [col for col in df.columns if col not in first]]
-
+        
+        # ensure session field matches data index
         if df['session'].unique()[0] != self.session:
-            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' +
-                          f'to {self.session} to match data index.')
+            # have to split up to appease Travis CI
+            wm1 = f'Changing events session field from {df["session"].unique()[0]} '
+            wm2 = f'to {self.session} to match data index.'
+            wm = wm1 + wm2
+            warnings.warn(wm)
             df['session'] = self.session
 
         return df

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -246,11 +246,8 @@ class EventReader(BaseCMLReader):
         
         # ensure session field matches data index
         if df['session'].unique()[0] != self.session:
-            # have to split up to appease Travis CI
-            wm1 = f'Changing events session field from {df["session"].unique()[0]} '
-            wm2 = f'to {self.session} to match data index.'
-            wm = wm1 + wm2
-            warnings.warn(wm)
+            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' +
+                          f'to {self.session} to match data index.')
             df['session'] = self.session
 
         return df

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -245,7 +245,8 @@ class EventReader(BaseCMLReader):
         df = df[first + [col for col in df.columns if col not in first]]
 
         if df['session'].unique()[0] != self.session:
-            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} to {self.session} to match data index.')
+            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} '\
+                          f'to {self.session} to match data index.')
             df['session'] = self.session     
 
         return df

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -245,7 +245,7 @@ class EventReader(BaseCMLReader):
         df = df[first + [col for col in df.columns if col not in first]]
 
         if df['session'].unique()[0] != self.session:
-            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' + 
+            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' +
                           f'to {self.session} to match data index.')
             df['session'] = self.session
 

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -245,7 +245,8 @@ class EventReader(BaseCMLReader):
         df = df[first + [col for col in df.columns if col not in first]]
 
         # ensure session field matches data index
-        if df['session'].unique()[0] != self.session:
+        # math events given session, other events given original session
+        if df['session'].unique()[0] != self.session or len(df['session'].unique()) < 1:
             warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' +
                           f'to {self.session} to match data index.')
             df['session'] = self.session

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -243,6 +243,11 @@ class EventReader(BaseCMLReader):
 
         first = ["eegoffset"]
         df = df[first + [col for col in df.columns if col not in first]]
+
+        if df['session'].unique()[0] != self.session:
+            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} to {self.session} to match data index.')
+            df['session'] = self.session     
+
         return df
 
 

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -245,9 +245,9 @@ class EventReader(BaseCMLReader):
         df = df[first + [col for col in df.columns if col not in first]]
 
         if df['session'].unique()[0] != self.session:
-            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} '\
+            warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' + 
                           f'to {self.session} to match data index.')
-            df['session'] = self.session     
+            df['session'] = self.session
 
         return df
 

--- a/cmlreaders/readers/readers.py
+++ b/cmlreaders/readers/readers.py
@@ -243,7 +243,7 @@ class EventReader(BaseCMLReader):
 
         first = ["eegoffset"]
         df = df[first + [col for col in df.columns if col not in first]]
-        
+
         # ensure session field matches data index
         if df['session'].unique()[0] != self.session:
             warnings.warn(f'Changing events session field from {df["session"].unique()[0]} ' +


### PR DESCRIPTION
Add support to PathFinder for system 4 files, including archived (replaced) elemem eeg.

Modify session number when loading events dataframe to match "session" (not "original session") in data index.  This resolves some issues with eeg not loading (since cmlreaders looks for the wrong session) as well as with the events dataframe having multiple values in the `session` field, due to math events receiving "session" and other events having "original session."  Also, clarifies for re-implants that session numbers increment instead of resetting.