### PR TITLE
Countdown event list error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Version 0.10.7
 --------------
 **2024-4-2**
 
-* Added ``correct_countdown_lists`` method, which applies to corrections to
+* Added ``correct_countdown_lists`` method, which applies corrections to
   ``list`` field of countdown events for sessions containing unityEPL-FR bug.
 
 Version 0.10.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,14 @@
 Changes
 =======
 Version 0.10.7
--------------
+--------------
 **2024-4-2**
 
 * Added ``correct_countdown_lists`` method, which applies to corrections to
   ``list`` field of countdown events for sessions containing unityEPL-FR bug.
 
 Version 0.10.6
--------------
+--------------
 **2024-3-8**
 
 Added ``event_process.py``, which contains ``correct_retrieval_offsets`` and
@@ -20,7 +20,7 @@ Added ``event_process.py``, which contains ``correct_retrieval_offsets`` and
   by ``mstime``, placing the rows (and EEG files) in chronological order.
 
 Version 0.10.5
--------------
+--------------
 **2024-1-24**
 
 * Added system 4 files to PathFinder, including ``archived_eeg`` which points to replaced elemem eeg
@@ -28,31 +28,31 @@ Version 0.10.5
   fixing issues where events dataframe contains ``original session`` value
   
 Version 0.10.4
--------------
+--------------
 **2023-8-1**
 
 * Python 3.11, non-fatal warning for negative eeg offsets, re-enable loading eeg in mne format
 
 Version 0.10.3
--------------
+--------------
 **2023-5-17**
 
 * Added functionality for loading scalp subject info (which is copied to rhino from Django each night)
 
 Version 0.10.2
--------------
+--------------
 **2022-12-1**
 
 * Added recarray backport, added an error message for empty events dataframes, and changed version number in CHANGELOG.txt for 0.10.1
 
 Version 0.10.1
--------------
+--------------
 **2021-11-4**
 
 * Bug fixes
 
 Version 0.10.0
--------------
+--------------
 **2021-11-4**
 
 * to_ptsa now stores events as a pandas MultiIndex, to match updates in PTSA v3.0.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 Changes
 =======
+Version 0.10.7
+-------------
+**2024-4-2**
+
+* Added ``correct_countdown_lists`` method, which applies to corrections to
+  ``list`` field of countdown events for sessions containing unityEPL-FR bug.
+
 Version 0.10.6
 -------------
 **2024-3-8**

--- a/cmlreaders/__init__.py
+++ b/cmlreaders/__init__.py
@@ -2,13 +2,14 @@ from collections import namedtuple
 
 from ._accessors import *  # noqa
 from .data_index import get_data_index  # noqa
-from .event_process import correct_retrieval_offsets, sort_eegfiles  # noqa
+from .event_process import correct_retrieval_offsets, sort_eegfiles, \
+    correct_countdown_lists  # noqa
 
 # n.b. the order below matters so as to avoid circular imports
 from .path_finder import PathFinder  # noqa
 from .readers import *  # noqa
 from .cmlreader import CMLReader  # noqa
 
-__version__ = "0.10.6"
+__version__ = "0.10.7"
 version_info = namedtuple("VersionInfo", "major,minor,patch")(
     *__version__.split('.'))

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -253,3 +253,6 @@ elemem_files = (
 
 # Offset corrections for retrieval events
 offset_corrections = ["protocols/r1/offset_corrections.csv"]
+
+# Countdown event list corrections
+countdown_errors = ["protocols/r1/countdown_errors.csv"]

--- a/cmlreaders/event_process.py
+++ b/cmlreaders/event_process.py
@@ -81,6 +81,7 @@ def sort_eegfiles(events):
 
     return events
 
+
 def correct_countdown_lists(events, reader):
     """Correct list values for countdown events with unityEPL-FR bug.
 
@@ -94,7 +95,7 @@ def correct_countdown_lists(events, reader):
     Returns
     -------
     events
-        A :class: `pd.DataFrame` with corrected list fields for countdown 
+        A :class: `pd.DataFrame` with corrected list fields for countdown
         events, as necessary.
 
     """
@@ -104,7 +105,7 @@ def correct_countdown_lists(events, reader):
     cde = countdown_errors[(countdown_errors['subject'] == reader.subject) &
                            (countdown_errors['experiment'] == reader.experiment) &
                            (countdown_errors['session'] == reader.session)]
-    
+
     # no correction necessary
     if len(cde) == 0:
         return events

--- a/cmlreaders/event_process.py
+++ b/cmlreaders/event_process.py
@@ -123,5 +123,6 @@ def correct_countdown_lists(events, reader):
                 lst.append(row.list)
 
         events['list'] = lst                     # set 'list' field
+        warnings.warn("Correcting list values for countdown events.")
 
         return events

--- a/cmlreaders/event_process.py
+++ b/cmlreaders/event_process.py
@@ -123,5 +123,5 @@ def correct_countdown_lists(events, reader):
                 lst.append(row.list)
 
         events['list'] = lst                     # set 'list' field
-        
+
         return events


### PR DESCRIPTION
Added `correct_countdown_lists` method, which applies corrections to list `field` of countdown events for sessions containing unityEPL-FR bug.