### PR TITLE
pyFR data recovery & loading EEG beyond recording

### DIFF
--- a/cmlreaders/__init__.py
+++ b/cmlreaders/__init__.py
@@ -10,6 +10,6 @@ from .path_finder import PathFinder  # noqa
 from .readers import *  # noqa
 from .cmlreader import CMLReader  # noqa
 
-__version__ = "0.10.7"
+__version__ = "0.10.8"
 version_info = namedtuple("VersionInfo", "major,minor,patch")(
     *__version__.split('.'))

--- a/cmlreaders/constants.py
+++ b/cmlreaders/constants.py
@@ -71,9 +71,11 @@ rhino_paths = {
     "contacts": [
         "protocols/{protocol}/subjects/{subject}/localizations/{localization}/montages/{montage}/neuroradiology/current_processed/contacts.json",
         "data/eeg/{subject_montage}/tal/{subject_montage}_talLocs_database_monopol.mat",
+        "data/eeg/{subject_montage}/tal/{subject_montage}_talLocs_database.mat",
     ],
     "matlab_contacts": [
         "data/eeg/{subject_montage}/tal/{subject_montage}_talLocs_database_monopol.mat",
+        "data/eeg/{subject_montage}/tal/{subject_montage}_talLocs_database.mat",
     ],
     # Report Data
     "session_summary": [

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -289,10 +289,15 @@ class SplitEEGReader(BaseEEGReader):
         #       {epoch[1]} < length {len(mmap)}"
         #        assert len(mmap[epoch[0]:epoch[1]]) == epoch[1] - epoch[0],
         #           f"epoch difference not equal to length of mmap {len(mmap)}"
-
-        data = np.array(
-            [[mmap[epoch[0] : epoch[1]] for mmap in memmaps] for epoch in self.epochs]
-        )
+        try:
+            data = np.array(
+                [[mmap[epoch[0] : epoch[1]] for mmap in memmaps] for epoch in self.epochs]
+            )
+        except ValueError:  # requesting event-epoched data beyond final sample of EEG
+            raise exc.MissingDataError(
+                "Unable to load EEG for some events because rel_stop parameter is " +
+                "beyond final sample of EEG recording."
+            )
 
         return data, contacts
 

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -727,7 +727,7 @@ class EEGReader(BaseCMLReader):
                         f"Dropping {len(ev) - len(evs)} events with epochs beyond the " +
                         "boundaries of the EEG recording."
                     )
-                    epochs = convert.events_to_epochs(evs, rel_start, rel_stop, sample_rate)
+                    ev = evs             # need to store in "ev" variable
 
                 epochs = convert.events_to_epochs(ev, rel_start, rel_stop, sample_rate)
 

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -723,9 +723,10 @@ class EEGReader(BaseCMLReader):
                 # only events within boundaries
                 evs = ev[(ev['eegoffset'] - rstart >= 0) & (ev['eegoffset'] + rstop <= n_samples)]
                 if len(evs) < len(ev):
+                    drop_idx = evs.index.difference(ev.index).to_numpy()   # event indices to drop
                     warnings.warn(
-                        f"Dropping {len(ev) - len(evs)} events with epochs beyond the " +
-                        "boundaries of the EEG recording."
+                        f"Dropping {len(ev) - len(evs)} event(s) at index(es) {drop_idx} " +
+                        "with epochs beyond the boundaries of the EEG recording."
                     )
                     ev = evs             # need to store in "ev" variable
 

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -723,7 +723,7 @@ class EEGReader(BaseCMLReader):
                 # only events within boundaries
                 evs = ev[(ev['eegoffset'] - rstart >= 0) & (ev['eegoffset'] + rstop <= n_samples)]
                 if len(evs) < len(ev):
-                    drop_idx = evs.index.difference(ev.index).to_numpy()   # event indices to drop
+                    drop_idx = ev.index.difference(evs.index).to_numpy()   # event indices to drop
                     warnings.warn(
                         f"Dropping {len(ev) - len(evs)} event(s) at index(es) {drop_idx} " +
                         "with epochs beyond the boundaries of the EEG recording."

--- a/cmlreaders/readers/electrodes.py
+++ b/cmlreaders/readers/electrodes.py
@@ -179,7 +179,7 @@ class MontageReader(BaseCMLReader):
                     df = df.merge(new_df, how='outer',
                                   left_index=True, right_index=True)
                 except BaseException as e:
-                    warnings.warn(f'Error loading column {col}.{c}: {e}.')
+                    warnings.warn(f'Error loading column {col}.{c}, omitting from dataframe.')
                     continue
 
         if hasattr(df.channel.iloc[0], "__len__"):

--- a/cmlreaders/readers/electrodes.py
+++ b/cmlreaders/readers/electrodes.py
@@ -181,6 +181,7 @@ class MontageReader(BaseCMLReader):
                                 left_index=True, right_index=True)
                 except BaseException as e:
                     warnings.warn(f'Error loading column {col}.{c}: {e}.')
+                    continue
 
         if hasattr(df.channel.iloc[0], "__len__"):
             channels = np.array([[ch[0], ch[1]] for ch in df.pop("channel")])

--- a/cmlreaders/readers/electrodes.py
+++ b/cmlreaders/readers/electrodes.py
@@ -178,7 +178,7 @@ class MontageReader(BaseCMLReader):
                                           columns=['{}.{}'.format(col, c)])
                     df = df.merge(new_df, how='outer',
                                   left_index=True, right_index=True)
-                except BaseException as e:
+                except BaseException:
                     warnings.warn(f'Error loading column {col}.{c}, omitting from dataframe.')
                     continue
 

--- a/cmlreaders/readers/electrodes.py
+++ b/cmlreaders/readers/electrodes.py
@@ -166,8 +166,7 @@ class MontageReader(BaseCMLReader):
             for c in subcols:
                 # if error for specific column, raise warning and omit column
                 try:
-                    datacol = [x[c] if x.shape else x[c].item() for x in
-                            arr[col]]
+                    datacol = [x[c] if x.shape else x[c].item() for x in arr[col]]
                     idxs = range(len(datacol))
                     new_datacol, new_idxs = list(
                         zip(*[(x, i) for (x, i) in zip(datacol, idxs)
@@ -175,10 +174,10 @@ class MontageReader(BaseCMLReader):
                                 or x.size > 0) and x)])
                     )
                     new_df = pd.DataFrame(np.array(new_datacol),
-                                        index=new_idxs,
-                                        columns=['{}.{}'.format(col, c)])
+                                          index=new_idxs,
+                                          columns=['{}.{}'.format(col, c)])
                     df = df.merge(new_df, how='outer',
-                                left_index=True, right_index=True)
+                                  left_index=True, right_index=True)
                 except BaseException as e:
                     warnings.warn(f'Error loading column {col}.{c}: {e}.')
                     continue


### PR DESCRIPTION
Updates to successfully load more pyFR data, including implementing loading of pyFR math events.  Changes include improved file search for matlab contacts files and try-except blocks to avoid missing data giving errors in otherwise loadable localization dataframes.

Also, on loading EEG for events where `rel_start` or `rel_stop` extends beyond the bounds of the EEG recording, those events are dropped, a warning is raised, and the EEG for remaining event epochs loads.