### PR TITLE
v0.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Changes
 =======
-Version 0.10.8
+Version 0.11.0
 --------------
 **2024-6-4**
 
 pyFR loading:
+
 * Implemented loading of pyFR math events.
 * PathFinder now searches multiple files for monpolar montage.
 * Try-except to avoid errors from missing fields in localization data.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,8 @@ pyFR loading:
 * PathFinder now searches multiple files for monpolar montage.
 * Try-except to avoid errors from missing fields in localization data.
 
-Loading EEG for event epochs beyond boundaries of EEG recording no longer raises error,
-  instead dropping unloadable epochs with a warning.
+Loading EEG for event epochs beyond boundaries of EEG recording no longer raises error, 
+instead dropping unloadable epochs with a warning.
 
 Version 0.10.7
 --------------

--- a/cmlreaders/__init__.py
+++ b/cmlreaders/__init__.py
@@ -10,6 +10,6 @@ from .path_finder import PathFinder  # noqa
 from .readers import *  # noqa
 from .cmlreader import CMLReader  # noqa
 
-__version__ = "0.10.8"
+__version__ = "0.11.0"
 version_info = namedtuple("VersionInfo", "major,minor,patch")(
     *__version__.split('.'))


### PR DESCRIPTION
cmlreaders version 0.11.0 (same as v0.10.8, updating versioning)

pyFR loading:
- Implemented loading of pyFR math events.
- PathFinder now searches multiple files for monpolar montage.
- Try-except to avoid errors from missing fields in localization data.

Loading EEG for event epochs beyond boundaries of EEG recording no longer raises error, instead dropping unloadable epochs with a warning.