### PR TITLE
patch v0.11.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 Changes
 =======
+Version 0.11.2
+--------------
+**2024-7-2**
+
+* Patch to load EEG for pre-RAM sessions without ``n_samples`` metadata.  Toggle off
+  event-epoch EEG boundary checks.
+
 Version 0.11.1
 --------------
 **2024-6-21**

--- a/cmlreaders/__init__.py
+++ b/cmlreaders/__init__.py
@@ -10,6 +10,6 @@ from .path_finder import PathFinder  # noqa
 from .readers import *  # noqa
 from .cmlreader import CMLReader  # noqa
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 version_info = namedtuple("VersionInfo", "major,minor,patch")(
     *__version__.split('.'))

--- a/cmlreaders/readers/eeg.py
+++ b/cmlreaders/readers/eeg.py
@@ -720,7 +720,8 @@ class EEGReader(BaseCMLReader):
             else:
                 # drop events beyond bounds of EEG samples
                 n_samples = sources["n_samples"]
-                if not isinstance(n_samples, np.ndarray):         # pass if multiple EEG files
+                # pass if no n_samples or if multiple EEG files
+                if n_samples and not isinstance(n_samples, np.ndarray):
                     rstart = convert.milliseconds_to_samples(rel_start, sample_rate)
                     rstop = convert.milliseconds_to_samples(rel_stop, sample_rate)
                     # only events within boundaries


### PR DESCRIPTION
Pre-RAM (pyFR) sessions do not have `n_samples` metadata, meaning the EEG boundary checks erroneously drop all events.

Update to pass EEG boundary checks if there is no `n_samples` information available.